### PR TITLE
Change collation to fit WordPress Standards and some cleaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,15 @@ Edit **manifests/vhosts.pp**. This is where you define virtualhosts and database
 
 Example:
 
-```apache::vhost { 'mysite.pv':
-	docroot       				=> 'path/to/your/site',
-	directory					=> 'path/to/your/site',
-	directory_allow_override	=> 'All',
-	ssl							=> true,
-	template                    => '/var/vagrant/conf/vhost.conf.erb',
-}```
+```
+apache::vhost { 'mysite.pv':
+	docroot							=> 'path/to/your/site',
+	directory						=> 'path/to/your/site',
+	directory_allow_override		=> 'All',
+	ssl								=> true,
+	template						=> '/var/vagrant/conf/vhost.conf.erb',
+}
+```
 
 *Note: I've provided a top-level wildcard SSL certificate. No further SSL certificate should be needed.
 
@@ -120,11 +122,13 @@ In addition to the *root* MySQL account the account *username* with the password
 
 To create a new database use the following example to edit manifests/mysql.pp
 
-```mysql_database { 'database_name':
-     ensure  => 'present',
-     charset => 'utf8',
-     collate => 'utf8_general_ci',
-}```
+```
+mysql_database { 'database_name':
+	ensure  => 'present',
+	charset => 'utf8',
+	collate => 'utf8_swedish_ci',
+}
+```
 
 ###Postfix Configuration
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ To create a new database use the following example to edit manifests/mysql.pp
 ```mysql_database { 'database_name':
      ensure  => 'present',
      charset => 'utf8',
-     collate => 'utf8_swedish_ci',
+     collate => 'utf8_general_ci',
 }```
 
 ###Postfix Configuration

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -221,28 +221,28 @@ class { 'mysql::server': }
 mysql_database { 'wordpress.stable.pv':
 	ensure  => 'present',
 	charset => 'utf8',
-	collate => 'utf8_swedish_ci',
+	collate => 'utf8_general_ci',
 	require => Class['mysql::server'],
 }
 
 mysql_database { 'wordpress.legacy.pv':
 	ensure  => 'present',
 	charset => 'utf8',
-	collate => 'utf8_swedish_ci',
+	collate => 'utf8_general_ci',
 	require => Class['mysql::server'],
 }
 
 mysql_database { 'wordpress.trunk.pv':
 	ensure  => 'present',
 	charset => 'utf8',
-	collate => 'utf8_swedish_ci',
+	collate => 'utf8_general_ci',
 	require => Class['mysql::server'],
 }
 
 mysql_database { 'wordpress.core.pv':
 	ensure  => 'present',
 	charset => 'utf8',
-	collate => 'utf8_swedish_ci',
+	collate => 'utf8_general_ci',
 	require => Class['mysql::server'],
 }
 


### PR DESCRIPTION
Hi,

This PR changes collation to fit WordPress Standards, [see in notes](http://codex.wordpress.org/Converting_Database_Character_Sets#The_basics_of_converting_a_database).
Better code presentation in README.md.

Hope this help.