### PR TITLE
Added a very simple mechanism to check for a custom dashboard. 

### DIFF
--- a/www/default/pv/dashboard.php
+++ b/www/default/pv/dashboard.php
@@ -1,0 +1,36 @@
+<html>
+<head>
+	<title>Primary Vagrant</title>
+</head>
+<body>
+
+	<h1>Welcome to Primary Vagrant</h1>
+
+<h2>About Primary Vagrant</h2>
+
+	<p>Primary Vagrant is an Apache Based Development Environment for working with WordPress on your local machine.</p>
+
+	<ul>
+		<li><a href="https://github.com/ChrisWiegman/Primary-Vagrant" target="_blank">View the Primary Vagrant Project on GitHub</a></li>
+	</ul>
+
+<h2>Primary Vagrant Tools</h2>
+
+	<ul>
+		<li><a href="http://phpmyadmin.pv" target="_blank">Manage MySQL with phpMyAdmin</a></li>
+		<li><a href="http://replacedb.pv" target="_blank">Easily Search and Replace MySQL database values with Search and Replace DB</a> (this makes migrating sites a breeze)</li>
+		<li><a href="http://webgrind.pv" target="_blank">Profile your application with Webgrind</a></li>
+		<li><a href="http://mailcatcher.pv:1080" target="_blank">Collect email with MailCatcher</a></li>
+	</ul>
+
+<h2>Development Sites</h2>
+
+	<ul>
+		<li><a href="http://core.wordpress.pv" target="_blank">WordPress Core (src folder for WordPress core development)</a></li>
+		<li><a href="http://legacy.wordpress.pv" target="_blank">WordPress Legacy Branch (old version - 4.2.x)</a></li>
+		<li><a href="http://stable.wordpress.pv" target="_blank">WordPress Stable Branch (current version - 4.3.x)</a></li>
+		<li><a href="http://trunk.wordpress.pv" target="_blank">WordPress Trunk (development) Version</a></li>
+	</ul>
+
+</body>
+</html>

--- a/www/default/pv/index.php
+++ b/www/default/pv/index.php
@@ -1,36 +1,8 @@
-<html>
-<head>
-	<title>Primary Vagrant</title>
-</head>
-<body>
+<?php
 
-	<h1>Welcome to Primary Vagrant</h1>
-
-<h2>About Primary Vagrant</h2>
-
-	<p>Primary Vagrant is an Apache Based Development Environment for working with WordPress on your local machine.</p>
-
-	<ul>
-		<li><a href="https://github.com/ChrisWiegman/Primary-Vagrant" target="_blank">View the Primary Vagrant Project on GitHub</a></li>
-	</ul>
-
-<h2>Primary Vagrant Tools</h2>
-
-	<ul>
-		<li><a href="http://phpmyadmin.pv" target="_blank">Manage MySQL with phpMyAdmin</a></li>
-		<li><a href="http://replacedb.pv" target="_blank">Easily Search and Replace MySQL database values with Search and Replace DB</a> (this makes migrating sites a breeze)</li>
-		<li><a href="http://webgrind.pv" target="_blank">Profile your application with Webgrind</a></li>
-		<li><a href="http://mailcatcher.pv:1080" target="_blank">Collect email with MailCatcher</a></li>
-	</ul>
-
-<h2>Development Sites</h2>
-
-	<ul>
-		<li><a href="http://core.wordpress.pv" target="_blank">WordPress Core (src folder for WordPress core development)</a></li>
-		<li><a href="http://legacy.wordpress.pv" target="_blank">WordPress Legacy Branch (old version - 4.2.x)</a></li>
-		<li><a href="http://stable.wordpress.pv" target="_blank">WordPress Stable Branch (current version - 4.3.x)</a></li>
-		<li><a href="http://trunk.wordpress.pv" target="_blank">WordPress Trunk (development) Version</a></li>
-	</ul>
-
-</body>
-</html>
+// Check for a custom dashboard, otherwise load default.
+if ( file_exists( './custom/index.php' ) ) {
+	include( './custom/index.php' );
+} else {
+	include( './dashboard.php' );
+}


### PR DESCRIPTION
I wanted a simple way to create a custom dashboard that didn't interfere with the main project. This was the simplest solution I came up with.

When navigating to http://pv, the script will first look for this file:
PV\www\default\pv\custom\index.php

If it does not exist, it will default to
PV\www\default\pv\dashboard.php

The custom folder will be a blank folder or not exist in the main PV repo so dashboard authors can just do a git clone directly into the empty custom folder.

Rules this would impose:
index.php would be the main file for all custom dashboards
one custom dashboard could be installed at a time

Not sure if this is too simple. Would love feedback!