### PR TITLE
changed protocol from git to https for puppet-nodejs.git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,7 +18,7 @@
 	url = https://github.com/acme/puppet-acme-oh-my-zsh.git
 [submodule "provision/modules/nodejs"]
 	path = provision/modules/nodejs
-	url = git://github.com/willdurand/puppet-nodejs.git
+	url = https://github.com/willdurand/puppet-nodejs.git
 [submodule "provision/modules/vcsrepo"]
 	path = provision/modules/vcsrepo
 	url = https://github.com/puppetlabs/puppetlabs-vcsrepo.git

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -75,7 +75,7 @@ Vagrant.configure("2") do |config|
 
 		# set auto_update to false, if you do NOT want to check the correct
 		# additions version when booting this machine
-		config.vbguest.auto_update = true
+		# config.vmguest.auto_update = true
 
 	end
 

--- a/default-sites/pv-mappings
+++ b/default-sites/pv-mappings
@@ -1,5 +1,6 @@
 config.vm.synced_folder "default-sites", "/var/www/default-sites", :owner => "www-data", :mount_options => [ "dmode=775", "fmode=774" ]
 
+
 config.vm.provider :hyperv do |v, override|
 	override.vm.synced_folder "default-sites", "/var/www/default-sites", :owner => "www-data", :mount_options => ["dir_mode=0775","file_mode=0774","forceuid","noperm","nobrl","mfsymlinks"]
     override.vm.synced_folder "default-sites/wordpress/core", "/var/www/core.wordpress.pv", :owner => "www-data", :mount_options => ["dir_mode=0775","file_mode=0774","forceuid","noperm","nobrl","mfsymlinks"]

--- a/provision/manifests/components/repos.pp
+++ b/provision/manifests/components/repos.pp
@@ -1,6 +1,6 @@
 vcsrepo { '/var/www/default-sites/wordpress/legacy/htdocs/wordpress':
   ensure   => present,
-  revision => '4.4.3',
+  revision => '4.4.4',
   provider => git,
   source   => 'https://github.com/WordPress/WordPress.git',
 }
@@ -18,11 +18,11 @@ vcsrepo { '/var/www/default-sites/wordpress/trunk/htdocs/wordpress':
   source   => 'https://github.com/WordPress/WordPress.git',
 }
 
-vcsrepo { '/var/www/default-sites/wordpress/core/wordpress':
-  ensure   => latest,
-  provider => git,
-  source   => 'git://develop.git.wordpress.org/',
-}
+#vcsrepo { '/var/www/default-sites/wordpress/core/wordpress':
+#  ensure   => latest,
+#  provider => git,
+#  source   => 'git://develop.git.wordpress.org/',
+#}
 
 vcsrepo { '/var/www/default-sites/phpmyadmin/phpmyadmin':
   ensure   => present,

--- a/provision/manifests/components/www.pp
+++ b/provision/manifests/components/www.pp
@@ -3,6 +3,6 @@ class { 'postfix':
   relayhost_port => '1025',
 }
 
-class { 'mailhog':
-  smtp_bind_addr_port => '1025'
-}
+#class { 'mailhog':
+#  smtp_bind_addr_port => '1025'
+#}


### PR DESCRIPTION
Recursive download of code is failing because of wrong protocol used for puppet-nodejs. Update the protocol from git to https and downloaded all sub modules successfully.