### PR TITLE
Change the order of commands in php puppet manifest file to prevent mysql from failing.

### DIFF
--- a/provision/init/05_php.pp
+++ b/provision/init/05_php.pp
@@ -44,6 +44,10 @@ class { '::php':
     'PHP/max_execution_time'  => '90',
   },
 } ->
+  exec { 'disable_php_mysql':
+    command => 'phpdismod mysql',
+    require => Class['php'],
+  } ->
   exec { 'php_codesniffer':
     command =>
       'git clone https://github.com/squizlabs/PHP_CodeSniffer.git /var/phpcs && sudo ln -s /var/phpcs/scripts/phpcs /usr/bin/phpcs && sudo ln -s /var/phpcs/scripts/phpcbf /usr/bin/phpcbf',
@@ -55,8 +59,4 @@ class { '::php':
       'git clone -b master https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git /var/wpcs && phpcs --config-set installed_paths /var/wpcs',
     require => Class['php'],
     creates => '/var/wpcs/README.md',
-  } ->
-  exec { 'disable_php_mysql':
-    command => 'phpdismod mysql',
-    require => Class['php'],
   }


### PR DESCRIPTION
Change the order of commands so that a possible failure to grab the wordpress coding standards does not inadverdantly cause the loss of php to be able to access mysql once the box finishes spinning up.

This addresses the issue faced in
https://github.com/ChrisWiegman/Primary-Vagrant/issues/82